### PR TITLE
travis: add Node.js 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - '9'
   - '8'
   - '6'
   - '4'
@@ -20,3 +21,5 @@ matrix:
       env: LINT=true
     - node_js: '8'
       env: COVERAGE=true
+  allow_failures:
+    - node_js: '9'


### PR DESCRIPTION
Allow failure because `npm` currently does not run on Node.js 9.