### PR TITLE
feat: remove Node.js v8

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [8, 10, 12, 14]
+        node-version: [10, 12, 14]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v2.3.1

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "test"
   },
   "engines": {
-    "node": "8 || 10 || 12 || >=14"
+    "node": "10 || 12 || >=14"
   },
   "scripts": {
     "pretest": "npm run -s lint",


### PR DESCRIPTION
BREAKING CHANGE: The minimum supported version of Node.js is now v10.